### PR TITLE
docs: Force README cache invalidation for PyPI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,4 +420,4 @@ This project is licensed under the **Mozilla Public License 2.0** - see the [LIC
   <strong>Built with ❤️ for the AI community</strong><br>
   <em>🔒 GPG signing ensures the authenticity and integrity of all code contributions</em>
 </p>
-
+<!-- Cache bust to update PyPI badge -->

--- a/README.md
+++ b/README.md
@@ -420,3 +420,4 @@ This project is licensed under the **Mozilla Public License 2.0** - see the [LIC
   <strong>Built with ❤️ for the AI community</strong><br>
   <em>🔒 GPG signing ensures the authenticity and integrity of all code contributions</em>
 </p>
+


### PR DESCRIPTION
This PR forces a cache invalidation for the README.md file to fix the version mismatch on the PyPI badge. The badge was showing an outdated version due to GitHub's CDN caching. Merging this PR should resolve the issue without any functional changes.